### PR TITLE
[22112085 강보성] 기능 개선 및 오류 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -626,8 +626,7 @@ def setup_paint_app(window):
     canvas.bind("<Enter>", change_cursor)
     canvas.bind("<Leave>", default_cursor)
 
-    canvas.bind("<Button-3>", show_coordinates)
-    canvas.bind("<ButtonRelease-3>", hide_coordinates)
+    canvas.bind("<Motion>", show_coordinates)
 
     canvas.bind("<MouseWheel>", zoom)
 
@@ -753,7 +752,7 @@ def change_cursor(event):
 def default_cursor(event):
     canvas.config(cursor="")
 
-# 우클릭을 누르면 우측 상단에 x, y 좌표값을 백분율로 표시
+#  우측 상단에 x, y 좌표값을 백분율로 표시
 def show_coordinates(event):
     canvas.delete("coord_text")  # 이전 좌표값 삭제
     width = canvas.winfo_width()
@@ -763,9 +762,6 @@ def show_coordinates(event):
     coord_text = f"<{x_percent:.1f}% / {100-y_percent:.1f}%>"
     canvas.create_text(10, 10, text=coord_text, anchor="nw", tags="coord_text")
 
-# 우클릭을 떼면 좌표값 삭제
-def hide_coordinates(event):
-    canvas.delete("coord_text")
 
 """
 shape로 그릴 도형을 선택할 시 호출되어 윤곽선, 내부 색 선택이 가능하게 해주는 함수


### PR DESCRIPTION
백분율 좌표를 오른쪽 클릭을 해야만 좌표값이 왼쪽 위에 떴었는데 클릭을 하지않고 커서 위치를 따라서 좌표를 표시하고 텍스트 상자에서 텍스트를 적어서 오른쪽 클릭을 해야 텍스트가 그림판에 추가 되었었는데 두개다 오른쪽 클릭을 해야했기 때문에 백분율 좌표를 커서위치로 나타냄으로써 텍스트 추가 오류 개선