### PR TITLE
[22221604 노은재] paint_start 함수에 대한 주석 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -1183,6 +1183,10 @@ current_stroke = []
 redo_strokes = []
 
 def paint_start(event): #획 시작
+    """
+    마우스 버튼을 눌렀을 때 호출되어 획을 시작하는 함수.
+    시작 지점의 좌표를 저장하고, 현재 획을 초기화한다.
+    """
     global x1, y1, current_stroke
     x1, y1 = event.x, event.y
     current_stroke = []


### PR DESCRIPTION
paint_start 함수는 마우스 버튼을 눌렀을 때 호출되어 획을 시작하는 역할을 함. 함수의 동작을 명확히 이해하고 코드를 쉽게 유지보수할 수 있도록 하기 위해 주석을 추가함.
- 함수의 목적 설명: paint_start 함수가 어떤 상황에서 호출되고, 어떤 역할을 하는지 설명함. 즉, 마우스 버튼을 눌렀을 때 획을 시작하는 함수임을 명확히 함
- 변수 초기화 설명: 함수가 호출될 때 x1, y1에 현재 마우스 위치를 저장하고, current_stroke를 초기화하는 작업을 한다는 것을 설명함. 이는 함수의 주요 동작을 이해하는 데 도움이 됨