### PR TITLE
[22012156 박규민] .jpg와 .gif 도  업로드 가능하게 기능개선

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,9 +5,11 @@ clear_paint : 그림판에 있는 그림을 다 지우는 기능
 button_delete : clear_paint의 버튼
 
 """
-
 from tkinter import *
 from tkinter import ttk
+from PIL import Image, ImageTk 
+from tkinter import filedialog
+from tkinter import messagebox
 import time #시간 계산을 위한 모듈
 import brush_settings  # brush_settings 모듈 임포트
 from brush_settings import change_brush_size, change_bg_color, change_brush_color, set_brush_mode, set_paint_mode_normal, set_paint_mode_pressure, paint_start, paint, dotted_paint
@@ -202,16 +204,20 @@ def on_leave(event):
 def upload_image():
     path = filedialog.askopenfilename()
     if path:
-        # 업로드 파일이 PNG파일인지 확인
-        if not path.lower().endswith('.png'):
-            messagebox.showerror("Invalid File", "PNG 파일만 업로드할 수 있습니다.")
+        # 업로드 파일이 JPG나 PNG 파일인지 확인
+        if not (path.lower().endswith('.png') or path.lower().endswith('.jpg')):
+            messagebox.showerror("잘못된 파일", "JPG나 PNG 파일만 업로드할 수 있습니다.")
             return
 
-        # 업로드 파일이 PNG일 때 업로드 성공
-        image = PhotoImage(file=path)
-        canvas.create_image(0, 0, anchor=NW, image=image)
-        canvas.image = image
-
+        # 업로드 파일이 JPG나 PNG일 때 업로드 성공
+        try:
+            image = Image.open(path)
+            image = ImageTk.PhotoImage(image)
+            canvas.create_image(0, 0, anchor=NW, image=image)
+            canvas.image = image
+        except Exception as e:
+            messagebox.showerror("오류", f"이미지를 열 수 없습니다: {e}")
+            
 # 문자열 드래그 시작
 def start_drag(event):
     drag_data["item"] = canvas.find_closest(event.x, event.y)[0]


### PR DESCRIPTION
총 두개의 커밋입니다.


기존에는 png파일만 업로드 가능했는데 
.jpg 사진파일도 업로드 가능하게 수정
pillow 라이브러리의 Image.open() 함수를 사용하여 JPEG 이미지를 열고, 이를 PhotoImage로 변환하는 방법을 사용했다.

PIL (Pillow) 라이브러리를 사용하여 GIF 파일의 프레임을 읽고
각 프레임을 순서대로 Tkinter 캔버스에 표시해야 한다. 이를 위해서는 after 메서드를 사용하여 프레임 간 딜레이를 구현했다.
 AnimatedGIF 클래스를 정의하여 GIF 파일의 모든 프레임을 읽고, update_frame 메서드를 사용하여 주기적으로 프레임을 업데이트한다. 업로드 버튼을 눌렀을 때 GIF 파일을 선택하면 애니메이션이 시작되고, JPG나 PNG 파일인 경우에는 정적 이미지로 표시된다.

