### PR TITLE
[22213502 이도영] 메인/서브 브러쉬 색 지정기능 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,46 @@ dynamic_brush = False
 previous_time = None
 previous_x, previous_y = None, None
 
+#+=================================================================================
+is_first_brush_color = True #선택하고 있는 색이 첫번째일 경우
+main_color = "black" # 메인 브러쉬 색을 저장할 변수
+sub_color = "white" #서브 브러쉬 색을 저장할 변수
+main_color_button, sub_color_button = None, None# 저장한 색을 불러오는 버튼
+
+def select_main_color(): #메인 색을 선택하여 브러쉬 색을 바꾸는 기능
+    global is_first_brush_color, brush_color, main_color
+    is_first_brush_color = True
+    brush_color = main_color
+
+def select_sub_color(): #서브 색을 선택하여 브러쉬 색을 바꾸는 기능
+    global is_first_brush_color, brush_color, sub_color
+    is_first_brush_color = False
+    brush_color = sub_color   
+
+def swap_selected_color(event): #선택된 색을 서로 교체하는 기능
+    global is_first_brush_color, brush_color, main_color, sub_color, main_color_button, sub_color_button
+    temp = sub_color
+    sub_color = main_color
+    main_color = temp
+    # 색을 서로 교체
+    main_color_button.config(bg=main_color)
+    sub_color_button.config(bg=sub_color)
+    # 교체된 색에 맞추어 버튼 색을 교체
+    if is_first_brush_color:
+        brush_color = main_color
+    else:
+        brush_color = sub_color
+    # 교체된 색을 바탕으로 현재 브러쉬 색을 업데이트
+
+def change_selected_color(color): #선택된 색을 교체할때 사용하는 기능
+    global is_first_brush_color, main_color, sub_color, main_color_button, sub_color_button
+    if is_first_brush_color:
+        main_color = color
+        main_color_button.config(bg=color)
+    else:
+        sub_color = color
+        sub_color_button.config(bg=color)
+#+=================================================================================
 
 # 벌집 색상 선택 함수
 def choose_hex_color():
@@ -339,6 +379,7 @@ def bind_shortcuts():
     window.bind("<w>", set_dotted_brush_mode)
     window.bind("<e>", set_double_line_brush_mode)
     window.bind("<Control-y>", rewrite_last_stroke) # redo 단축키 ctrl+shift+z
+    window.bind("x", swap_selected_color) #메인/서브 브러쉬 색 스왑 단축키 : X
 
 # brush_settings.initialize_globals(globals())
 
@@ -530,6 +571,7 @@ def set_brush_color(color):
     brush_color = color
     # spray_brush의 색상 변경을 위한 코드 추가
     spray_brush.set_brush_color(brush_color)
+    change_selected_color(color)
 
 # 사용자 정의 색상을 설정하고 팔레트에 추가하는 함수
 def set_custom_color(r_entry, g_entry, b_entry, palette_frame):
@@ -909,6 +951,15 @@ def setup_paint_app(window):
     frame_count = Frame(window)
     frame_count.pack(side=RIGHT)
 
+
+#+=================================================================================
+    #스왑가능한 색상 컬러 버튼
+    global main_color, sub_color, main_color_button, sub_color_button
+    main_color_button = Button(labelframe_brush, bg=main_color, width=2, height=1, command= select_main_color)
+    main_color_button.pack(side=LEFT, padx=2, pady=2)
+    sub_color_button = Button(labelframe_brush, bg=sub_color, width=2, height=1, command= select_sub_color)
+    sub_color_button.pack(side=LEFT, padx=2, pady=2)
+#+=================================================================================
 
 
     # 에어브러쉬 속성 조절 버튼 추가
@@ -1869,5 +1920,3 @@ timer.start()
 update_timer()
 
 window.mainloop()
-
-


### PR DESCRIPTION
- 위젯 좌측 상단에 브러쉬의 메인/서브 색이 표시되는 버튼 추가(초기에는 메인: 검정색, 서브: 하얀색) 
- 메인/서브 색 버튼을 선택하면, 해당하는 색으로 브러쉬 컬러 교체
- 팔레트에서 색을 교체 시, 선택한 색이 메인/서브인지에 따라 해당하는 색이 교체 (ex: 메인색으로 브러쉬 색을 지정하고 있을때 색 교체시, 메인 컬러 교체/서브 컬러는 유지) 
- 단축키 : "X"키를 누를시 메인/서브 색 스왑(색이 서로 바뀜)