### PR TITLE
[22213482 박대형] 마우스 올려두면 해당 버튼 단축키 팝업, 색상 팔레트 용도 명시

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ previous_x, previous_y = None, None
 
 # 벌집 색상 선택 함수
 def choose_hex_color():
-    color = askcolor()[1]
+    color = askcolor(title="벌집 색상 선택")[1]
     if color:
         draw_honeycomb_pattern(canvas, hex_color=color)
 
@@ -85,7 +85,7 @@ def pencil_brush(event, canvas):
 
 # 벽돌 색상 선택 함수
 def choose_brick_line_color():
-    color = askcolor()[1]
+    color = askcolor(title="벽돌 색상 선택")[1]
     if color:
         draw_brick_pattern(canvas, line_color=color)
 
@@ -551,12 +551,12 @@ def erase(event, canvas):
     canvas.create_oval(x1, y1, x2, y2, fill=bg_color, outline=bg_color, width=brush_size) # 브러쉬 사이즈 조절
 
 def change_bg_color(canvas):
-    bg_color = askcolor()
+    bg_color = askcolor(title="배경 색상 선택")
     canvas.config(bg=bg_color[1])
 
 def change_brush_color(event=None):
     global brush_color
-    selected_color = askcolor()[1]
+    selected_color = askcolor(title="브러쉬 색상 선택")[1]
     if selected_color:
         brush_color = selected_color
         set_brush_color(brush_color)
@@ -1079,8 +1079,8 @@ shape_fill_color : 도형의 내부 색
 
 def select_shape_color():
     global shape_outline_color, shape_fill_color
-    shape_outline_color = askcolor()[1]  # 윤곽선 색상 선택
-    shape_fill_color = askcolor()[1]  # 내부 색상 선택
+    shape_outline_color = askcolor(title="윤곽선 색상 선택")[1]  # 윤곽선 색상 선택
+    shape_fill_color = askcolor(title="내부 색상 선택")[1]  # 내부 색상 선택
 
 # 사각형 그리기
 def create_rectangle(event=None):

--- a/main.py
+++ b/main.py
@@ -199,6 +199,49 @@ def on_enter(event):
 def on_leave(event):
     event.widget.config(bg="SystemButtonFace")
 
+class ToolTip(object):
+
+    def __init__(self, widget):
+        self.widget = widget
+        self.tipwindow = None
+        self.id = None
+        self.x = self.y = 0
+
+    def showtip(self, text):
+        "Display text in tooltip window"
+        self.text = text
+        if self.tipwindow or not self.text:
+            return
+        x, y, cx, cy = self.widget.bbox("insert")
+        x = x + self.widget.winfo_rootx() + 30
+        y = y + cy + self.widget.winfo_rooty() +20
+        self.tipwindow = tw = Toplevel(self.widget)
+        tw.wm_overrideredirect(1)
+        tw.wm_geometry("+%d+%d" % (x, y))
+        label = Label(tw, text=self.text, justify=CENTER,
+                      background="#ffffe0", relief=SOLID, borderwidth=1,
+                      font=("Arial", "8", "normal"))
+        label.grid(row=0, column=0, sticky="nsew")  # grid로 배치
+
+    def hidetip(self):
+        tw = self.tipwindow
+        self.tipwindow = None
+        if tw:
+            tw.destroy()
+
+def CreateToolTip(widget, text):
+    toolTip = ToolTip(widget)
+    def enter(event):
+        event.widget.config(bg="light blue")
+        toolTip.showtip(text)
+    def leave(event):
+        toolTip.hidetip()
+        event.widget.config(bg="SystemButtonFace")
+    widget.bind('<Enter>', enter)
+    widget.bind('<Leave>', leave)
+
+
+
 def upload_image():
     path = filedialog.askopenfilename()
     if path:
@@ -858,17 +901,20 @@ def setup_paint_app(window):
     button_erase_last_stroke.grid(row=2, column=1)
     button_erase_last_stroke.bind("<Enter>", on_enter)  # 마우스가 버튼 위에 올라갔을 때의 이벤트 핸들러 등록
     button_erase_last_stroke.bind("<Leave>", on_leave)  # 마우스가 버튼을 벗어났을 때의 이벤트 핸들러 등록
+    CreateToolTip(button_erase_last_stroke, text = '(Ctrl+Z)')
 
     button_redo_last_stroke = Button(labelframe_additional, text="Redo", command=rewrite_last_stroke)
     button_redo_last_stroke.grid(row=2, column=2)
     button_redo_last_stroke.bind("<Enter>", on_enter)  # 마우스가 버튼 위에 올라갔을 때의 이벤트 핸들러 등록
     button_redo_last_stroke.bind("<Leave>", on_leave)  # 마우스가 버튼을 벗어났을 때의 이벤트 핸들러 등록
+    CreateToolTip(button_redo_last_stroke, text = '(Ctrl+Y)')
 
     #all clear
     button_clear = Button(labelframe_additional, text="All Clear", command=lambda: clear_paint(canvas))
     button_clear.grid(row=1, column=3)
     button_clear.bind("<Enter>", on_enter)  # 마우스가 버튼 위에 올라갔을 때의 이벤트 핸들러 등록
     button_clear.bind("<Leave>", on_leave)  # 마우스가 버튼을 벗어났을 때의 이벤트 핸들러 등록
+    CreateToolTip(button_clear, text = '(C)')
 
     #도형 모양 선택하는 버튼 생성
     button_choose_shape = Button(labelframe_additional, text="shape", command=choose_shape)


### PR DESCRIPTION
[기능추가] 메인화면에서 단축키가 할당된 버튼 위에 마우스 커서를 올리면 해당 버튼의 단축키 작게 팝업

>> 단축키를 할당하고도 단축키가 할당되어있는지 알 수 있는 방법이 없습니다.
메인화면 버튼들 중 단축키가 할당되어있는 Undo, Redo, All Clear에 마우스 커서를 올려둘 시
해당 버튼의 단축키를 작게 팝업하는 코드를 추가했습니다.


[기능추가] 색 선택시 어디에 사용할 색을 고르는지 명시

>> 도형 선택 후 색상 팔레트가 두 번 팝업되는데(윤곽선, 내부색)
아무 설명도 없이 두 번 뜨기에 기능을 명시할 필요를 느꼈습니다.
해당 팝업에 askcolor()의 title 옵션을 통해 어디에 사용할 색을 고르는지 기능을 추가했습니다.