### PR TITLE
[22012135 백재열] 기능추가 : 캔버스 중앙 기준 회전 , 중복 코드 제거

### DIFF
--- a/TransformationHandler.py
+++ b/TransformationHandler.py
@@ -5,24 +5,22 @@ class TransformationHandler:
         self.canvas = canvas
 
     def flip_horizontal(self):
+        self._flip_coordinates(horizontal=True)
+
+    def flip_vertical(self):
+        self._flip_coordinates(horizontal=False)
+
+    def _flip_coordinates(self, horizontal=True):
         objects = self.canvas.find_all()
         self.canvas.update()
         canvas_width = self.canvas.winfo_width()
-        for obj in objects:
-            coords = self.canvas.coords(obj)
-            for i in range(len(coords)):
-                if i % 2 == 0:  # x 좌표를 반전시킵니다.
-                    coords[i] = canvas_width - coords[i]
-            self.canvas.coords(obj, *coords)
-
-    def flip_vertical(self):
-        objects = self.canvas.find_all()
-        self.canvas.update()
         canvas_height = self.canvas.winfo_height()
         for obj in objects:
             coords = self.canvas.coords(obj)
             for i in range(len(coords)):
-                if i % 2 != 0:  # y 좌표를 반전시킵니다.
+                if horizontal and i % 2 == 0:  # x 좌표를 반전시킵니다.
+                    coords[i] = canvas_width - coords[i]
+                elif not horizontal and i % 2 != 0:  # y 좌표를 반전시킵니다.
                     coords[i] = canvas_height - coords[i]
             self.canvas.coords(obj, *coords)
 
@@ -31,13 +29,25 @@ class TransformationHandler:
         self.canvas.update()
         canvas_width = self.canvas.winfo_width()
         canvas_height = self.canvas.winfo_height()
+        canvas_center_x = canvas_width / 2
+        canvas_center_y = canvas_height / 2
+
         for obj in objects:
             coords = self.canvas.coords(obj)
             new_coords = []
             for i in range(0, len(coords), 2):
-                x = coords[i]
-                y = coords[i + 1]
+                x = coords[i] - canvas_center_x
+                y = coords[i + 1] - canvas_center_y
                 new_x = y
-                new_y = canvas_width - x
-                new_coords.extend([new_x, new_y])
+                new_y = -x
+                new_coords.extend([new_x + canvas_center_x, new_y + canvas_center_y])
             self.canvas.coords(obj, *new_coords)
+
+# 예시 사용법
+# root = Tk()
+# canvas = Canvas(root, width=400, height=400)
+# canvas.pack()
+# handler = TransformationHandler(canvas)
+# handler.flip_horizontal()
+# handler.flip_vertical()
+# handler.rotate_90()


### PR DESCRIPTION
1. 중복 코드 제거 : 'flip_horizontal'과 'flip_vertical'에서 유사한 코드가 중복되므로 이를 별도의 함수로 분리하여 재사용성을 높입니다.

2. 캔버스 중앙 기준 회전 : 'rotate_90' 함수는 캔버스의 중앙을 기준으로 회전하도록 수정합니다.