### PR TITLE
[22113644 이승형] Emphasis Effect 변형 기능 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,58 @@ def draw_emphasis(event):
     y_radius = rect_height * 0.8
     canvas.create_oval(center_x - x_radius, center_y - y_radius, center_x + x_radius, center_y + y_radius, fill="white", outline="white", tags="temp_shape")
 
+def create_rectangle_emphasis_effect(event=None):
+    # 마우스 왼쪽 버튼 클릭 시 start_rectangle_emphasis 함수를 호출하도록 설정
+    canvas.bind("<Button-1>", start_rectangle_emphasis)
+
+def start_rectangle_emphasis(event):
+    global start_x, start_y, current_shape
+    # 마우스 클릭 지점을 시작점으로 설정
+    start_x, start_y = event.x, event.y
+    current_shape = None
+    # 마우스 움직임에 따라 draw_rectangle_emphasis 함수를 호출하고, 버튼이 놓여지면 finish_emphasis 함수 호출
+    canvas.bind("<B1-Motion>", draw_rectangle_emphasis)
+    canvas.bind("<ButtonRelease-1>", finish_emphasis)
+
+# 기존의 draw_emphasis 함수를 수정하여 정사각형 비율로 투명한 배경의 강조 효과를 그리는 함수
+def draw_rectangle_emphasis(event):
+    global start_x, start_y
+    canvas.delete("temp_shape")
+    end_x, end_y = event.x, event.y
+    
+    center_x = (start_x + end_x) / 2
+    center_y = (start_y + end_y) / 2
+
+    # 정사각형의 크기를 결정합니다. 가로와 세로 중 더 긴 거리를 정사각형의 한 변으로 합니다.
+    side_length = max(abs(end_x - start_x), abs(end_y - start_y))
+    end_x = start_x + math.copysign(side_length, end_x - start_x)
+    end_y = start_y + math.copysign(side_length, end_y - start_y)
+
+    # 사각형의 대각선을 기준으로 원의 반지름을 결정
+    radius = min(abs(end_x - start_x), abs(end_y - start_y)) / 3
+
+    angle = 0
+    while angle < 360:
+        radian_angle = math.radians(angle)
+
+        # 원의 경계까지의 끝점
+        circle_x = center_x + radius * math.cos(radian_angle)
+        circle_y = center_y + radius * math.sin(radian_angle)
+
+        # 사각형의 테두리에서 시작점 계산
+        if abs(math.cos(radian_angle)) > abs(math.sin(radian_angle)):
+            scale = abs((end_x - start_x) / 2 / math.cos(radian_angle))
+        else:
+            scale = abs((end_y - start_y) / 2 / math.sin(radian_angle))
+
+        line_start_x = center_x + scale * math.cos(radian_angle)
+        line_start_y = center_y + scale * math.sin(radian_angle)
+
+        # 선 그리기
+        canvas.create_line(line_start_x, line_start_y, circle_x, circle_y, fill="black", width=random.randint(1, 3), tags="temp_shape")
+
+        angle += random.randint(1, 5)  # 각도 증가
+
 def finish_emphasis(event):
     global current_shape
     canvas.unbind("<B1-Motion>")
@@ -1097,8 +1149,9 @@ def setup_paint_app(window):
     cut_menu.add_command(label="2 cut", command=lambda: draw_comic_cut(2))
     cut_menu.add_command(label="3 cut", command=lambda: draw_comic_cut(3))
     cut_menu.add_command(label="4 cut", command=lambda: draw_comic_cut(4))
-    # 컷 강조 효과 서브메뉴 생성
+    # 컷 강조 효과 서브메뉴 생성    
     cartoon_menu.add_command(label="Emphasis Effect", command=create_emphasis_effect)
+    cartoon_menu.add_command(label="Emphasis Rectangle Effect", command=create_rectangle_emphasis_effect)
 
     file_menu.add_command(label="Open New Window", command=create_new_window) # File 메뉴에 Open New Window 기능 버튼 추가
     file_menu.add_command(label="Add Image", command=upload_image) # File 메뉴에 Add Image 기능 버튼 추가

--- a/main.py
+++ b/main.py
@@ -133,7 +133,10 @@ def draw_emphasis(event):
 
 def create_rectangle_emphasis_effect(event=None):
     # 마우스 왼쪽 버튼 클릭 시 start_rectangle_emphasis 함수를 호출하도록 설정
+    global radius_factor # 원의 반지름을 결정하는 변수
+    radius_factor = 3
     canvas.bind("<Button-1>", start_rectangle_emphasis)
+    canvas.bind("<MouseWheel>", adjust_radius)  # 마우스 휠 이벤트 바인딩
 
 def start_rectangle_emphasis(event):
     global start_x, start_y, current_shape
@@ -159,7 +162,7 @@ def draw_rectangle_emphasis(event):
     end_y = start_y + math.copysign(side_length, end_y - start_y)
 
     # 사각형의 대각선을 기준으로 원의 반지름을 결정
-    radius = min(abs(end_x - start_x), abs(end_y - start_y)) / 3
+    radius = min(abs(end_x - start_x), abs(end_y - start_y)) / radius_factor
 
     angle = 0
     while angle < 360:
@@ -182,6 +185,15 @@ def draw_rectangle_emphasis(event):
         canvas.create_line(line_start_x, line_start_y, circle_x, circle_y, fill="black", width=random.randint(1, 3), tags="temp_shape")
 
         angle += random.randint(1, 5)  # 각도 증가
+
+def adjust_radius(event):    
+    global radius_factor
+    # 이벤트 delta를 사용하여 반지름 조절
+    radius_factor -= event.delta / 120  # 대부분의 OS에서 한 휠 단계는 delta 120입니다.
+    if radius_factor > 6:  # 최소 반지름 제한
+        radius_factor = 6
+    if radius_factor < 2:  # 최대 반지름 제한
+        radius_factor = 2
 
 def finish_emphasis(event):
     global current_shape

--- a/main.py
+++ b/main.py
@@ -68,7 +68,13 @@ def draw_comic_cut(cut_number):
 # 강조 효과 그리는 함수
 def create_emphasis_effect(event=None):
     # 마우스 왼쪽 버튼 클릭 시 start_emphasis 함수를 호출하도록 설정
+    select_emphasis_line_color()
     canvas.bind("<Button-1>", start_emphasis)
+
+#강조 효과 색상 선택 함수
+def select_emphasis_line_color():
+    global emphasis_fill_color
+    emphasis_fill_color = askcolor()[1]  # 윤곽선 색상 선택   
 
 def start_emphasis(event):
     global start_x, start_y, current_shape
@@ -77,10 +83,10 @@ def start_emphasis(event):
     current_shape = None
     # 마우스 움직임에 따라 draw_emphasis 함수를 호출하고, 버튼이 놓여지면 finish_emphasis 함수 호출
     canvas.bind("<B1-Motion>", draw_emphasis)
-    canvas.bind("<ButtonRelease-1>", finish_emphasis)
+    canvas.bind("<ButtonRelease-1>", finish_emphasis) 
 
 def draw_emphasis(event):
-    global start_x, start_y, current_shape
+    global start_x, start_y, current_shape, emphasis_fill_color
     # 이전에 그려진 임시 도형 삭제
     canvas.delete("temp_shape")
     # 마우스 위치를 끝점으로 설정
@@ -123,7 +129,7 @@ def draw_emphasis(event):
         line_width = random.randint(1, 3)
 
         # 계산된 위치와 굵기로 선 그리기
-        canvas.create_line(center_x, center_y, x, y, fill="black", width=line_width, tags="temp_shape")
+        canvas.create_line(center_x, center_y, x, y, fill=emphasis_fill_color, width=line_width, tags="temp_shape")
         angle += angle_step
 
     # 중심에 흰색 타원 그리기 (사각형 영역에 대한 비율로 크기 조정)
@@ -135,6 +141,7 @@ def create_rectangle_emphasis_effect(event=None):
     # 마우스 왼쪽 버튼 클릭 시 start_rectangle_emphasis 함수를 호출하도록 설정
     global radius_factor # 원의 반지름을 결정하는 변수
     radius_factor = 3
+    select_emphasis_line_color()
     canvas.bind("<Button-1>", start_rectangle_emphasis)
     canvas.bind("<MouseWheel>", adjust_radius)  # 마우스 휠 이벤트 바인딩
 
@@ -149,7 +156,7 @@ def start_rectangle_emphasis(event):
 
 # 기존의 draw_emphasis 함수를 수정하여 정사각형 비율로 투명한 배경의 강조 효과를 그리는 함수
 def draw_rectangle_emphasis(event):
-    global start_x, start_y
+    global start_x, start_y, emphasis_fill_color
     canvas.delete("temp_shape")
     end_x, end_y = event.x, event.y
     
@@ -182,7 +189,7 @@ def draw_rectangle_emphasis(event):
         line_start_y = center_y + scale * math.sin(radian_angle)
 
         # 선 그리기
-        canvas.create_line(line_start_x, line_start_y, circle_x, circle_y, fill="black", width=random.randint(1, 3), tags="temp_shape")
+        canvas.create_line(line_start_x, line_start_y, circle_x, circle_y, fill=emphasis_fill_color, width=random.randint(1, 3), tags="temp_shape")
 
         angle += random.randint(1, 5)  # 각도 증가
 


### PR DESCRIPTION
# PR #516 의 기존 기능을 추가, 보완하였다.

### Commit 1: 기존의 Emphasis Effect는 먼저 그린 그림 위에 덮어씌우는 형태이지만, 추가된 Rectangle Emphasis Effect는 선을 계산을 달리하여, `기존의 그림을 보존하며 Effect를 적용`시킬 수 있다. 

### Commit 2: Rectangle Emphasis Effect 내부의 방사형 선의 경계점을 늘리거나 줄일 수 있다. 마우스휠로 동작하며, 아래로 내리면 내부의 경계점이 작아져 선이 길어지며, 위로 올리면 내부의 경계점이 커져서 선이 짧아진다. `휠을 내리며 이펙트의 사이즈를 살짝 바꾸면 조절이 가능`하다. 총 5단계로 구성되어있다. 

### Commit 3: Emphasis Effect와 Rectangle Emphasis Effect의 방사형 강조선에 `색상을 선택하는 기능을 추가`하였다. 강조 효과를 선택하면 색상 선택창이 출력된다. 기존의 select_shape_color() 함수를 변형시켰다.

---
![image](https://github.com/insung0-dklee/OSS_Paint_2024-1/assets/102710821/2f4b54a0-855c-4a48-afd2-1a1407549e8a)

[좌: 기존의 Emphasis Effect, 우: 추가된 Rectangle Emphasis Effect]