### PR TITLE
[22311911 정혜웅] shape의 arrow선택시 색 설정창이 두번 나오는 것을 바꿈

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ clear_paint : 그림판에 있는 그림을 다 지우는 기능
 button_delete : clear_paint의 버튼
 
 """
-
 from tkinter import *
 from tkinter import ttk
 import time #시간 계산을 위한 모듈


### PR DESCRIPTION
화살표 모양을 선택했을 시에 채색부분과 윤곽선색을 선택해도 채색부분의 색으로만 화살표의 색이 결정되었는데 이에 두번째 뜨는  윤곽선 색 선택창이 뜨는 것이 불필요하다고 생각하여 

# 내부 색상 선택
def select_shape_color():
    global shape_fill_color 
    shape_fill_color = askcolor()[1]  
# 윤곽선 색상 선택
def select_outline_color():
    global outline_color
    outline_color = askcolor()[1]

두가지 전역 함수로 나누었으며 화살표를 그리는 함수에는 select_shape_color만을 호출하여 색상 창이 두번 뜨는 것을 막았다.
또한 다른 모든 shape목록에 들어가는 그리기 함수들에 추가로 select_outline_color()를 호출하여 선이 아닌 다른 도형들은 윤곽선과 채색창이 정상적으로 뜨도록 바꾸었다.

# 화살표 그리기
def create_arrow(event=None):
    select_shape_color()
    canvas.bind("<Button-1>", start_arrow)

# 화살표의 선 부분
    current_shape = canvas.create_line(start_x, start_y, end_x, end_y, fill = shape_fill_color, tags="temp_shape")
# 화살표의 머리부분
    current_arrow= canvas.create_polygon(end_x, end_y, left_x, left_y, right_x, right_y, fill = shape_fill_color, tags="temp_shape")